### PR TITLE
Use correct gem name `rubyfarm-bisect` to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ By using rubyfarm-bisect, you don't have to worry about:
 You need to install rubyfarm-bisect.
 
 ```
-$ gem install rubyfarm-biesct
+$ gem install rubyfarm-bisect
 ```
 
 You also need to be able to use "docker" command without "sudo".


### PR DESCRIPTION
This pull request addresses incorrect gem name at README.

* Environment

```
% ruby -v
ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin19]
```

* Without this change:

```ruby
% gem install rubyfarm-biesct
ERROR:  Could not find a valid gem 'rubyfarm-biesct' (>= 0) in any repository
ERROR:  Possible alternatives: rubyfarm-bisect, ruby-freenect, ruby-cares, ruby-fitbit, ruby-framenet
```

* With this change:

```ruby
% gem install rubyfarm-bisect
Fetching rubyfarm-bisect-1.1.1.gem
Successfully installed rubyfarm-bisect-1.1.1
Parsing documentation for rubyfarm-bisect-1.1.1
Installing ri documentation for rubyfarm-bisect-1.1.1
Done installing documentation for rubyfarm-bisect after 0 seconds
1 gem installed
%
```